### PR TITLE
Stricter types

### DIFF
--- a/src/Stat.php
+++ b/src/Stat.php
@@ -25,7 +25,7 @@ class Stat
      * although it is only one of many different mathematical averages.
      * It is a measure of the central location of the data.
      * If data is empty, null is returned
-     * @param array<mixed> $data array of data
+     * @param array<int|float> $data array of data
      * @return int|float|null arithmetic mean or null if data is empty
      */
     public static function mean(array $data): int|float|null
@@ -218,7 +218,7 @@ class Stat
      * the values tend to be close to the mean of the set,
      * while a high standard deviation indicates that
      * the values are spread out over a wider range.
-     * @param array<mixed> $data
+     * @param array<int|float> $data
      * @param int|null $round whether to round the result
      * @return float|null the population standard deviation or null, if data is empty
      */
@@ -234,7 +234,7 @@ class Stat
 
     /**
      * Return dispersion of the numeric data.
-     * @param array<mixed> $data
+     * @param array<int|float> $data
      * @param int|null $round whether to round the result
      * @return float|null the dispersion of data or null if data is empty
      */
@@ -258,7 +258,7 @@ class Stat
 
     /**
      * Return the standard deviation of the numeric data.
-     * @param array<mixed> $data
+     * @param array<int|float> $data
      * @param int|null $round whether to round the result
      * @return float|null the standard deviation of the numeric data or null if data size is less than 2
      */
@@ -274,7 +274,7 @@ class Stat
 
     /**
      * Return the variance from the numeric data.
-     * @param array<mixed> $data
+     * @param array<int|float> $data
      * @param int|null $round whether to round the result
      * @return float|null the variance or null if data size is less than 2
      */
@@ -300,7 +300,7 @@ class Stat
      * Return the geometric mean of the numeric data.
      * That is the number that can replace each of these numbers so that their product
      * does not change.
-     * @param mixed[] $data
+     * @param array<int|float> $data
      * @param int|null $round whether to round the result
      * @return float|null geometric mean or null if data is empty
      */
@@ -321,7 +321,7 @@ class Stat
 
     /**
      * Return the harmonic mean (the reciprocal of the arithmetic mean) of the numeric data.
-     * @param array<mixed> $data
+     * @param array<int|float> $data
      * @param mixed[] $weights additional weight to the elements (as if there were several of them)
      * @param int|null $round whether to round the result
      * @return float|null harmonic mean or null if data is empty

--- a/src/Statistics.php
+++ b/src/Statistics.php
@@ -15,6 +15,12 @@ class Statistics
      * @var array<mixed>
      */
     private array $values = [];
+    /**
+     * Whether array contains not a numbers
+     *
+     * @var bool
+     */
+    private ?bool $containsNan = null;
 
     /**
      * @param array<mixed> $values
@@ -155,7 +161,7 @@ class Statistics
      */
     public function mean(): int|float|null
     {
-        return Stat::mean($this->values);
+        return (is_null($this->numericalArray())) ? null : Stat::mean($this->numericalArray());
     }
 
     /**
@@ -214,7 +220,7 @@ class Statistics
      */
     public function stdev(?int $round = null): ?float
     {
-        return Stat::stdev($this->values, $round);
+        return (is_null($this->numericalArray())) ? null : Stat::stdev($this->numericalArray(), $round);
     }
 
     /**
@@ -225,7 +231,7 @@ class Statistics
      */
     public function variance(?int $round = null): ?float
     {
-        return Stat::variance($this->values, $round);
+        return (is_null($this->numericalArray())) ? null : Stat::variance($this->numericalArray(), $round);
     }
 
     /**
@@ -236,7 +242,7 @@ class Statistics
      */
     public function pstdev(?int $round = null): ?float
     {
-        return Stat::pstdev($this->values, $round);
+        return (is_null($this->numericalArray())) ? null : Stat::pstdev($this->numericalArray(), $round);
     }
 
     /**
@@ -247,7 +253,7 @@ class Statistics
      */
     public function pvariance(?int $round = null): ?float
     {
-        return Stat::pvariance($this->values, $round);
+        return (is_null($this->numericalArray())) ? null : Stat::pvariance($this->numericalArray(), $round);
     }
 
     /**
@@ -258,17 +264,23 @@ class Statistics
      */
     public function geometricMean(?int $round = null): ?float
     {
-        return Stat::geometricMean($this->values, $round);
+        return (is_null($this->numericalArray())) ? null : Stat::geometricMean($this->numericalArray(), $round);
     }
 
     /**
      * Return the harmonic mean of the numeric data.
+     *
      * @param int|null $round whether to round the result
+     * @param mixed[] $weights additional weight to the elements (as if there were several of them)
      * @see Stat::harmonicMean()
      */
-    public function harmonicMean(?int $round = null): ?float
+    public function harmonicMean(?int $round = null, ?array $weights = null): ?float
     {
-        return Stat::harmonicMean($this->values, null, $round);
+        return (is_null($this->numericalArray())) ? null : Stat::harmonicMean(
+            $this->numericalArray(),
+            $weights,
+            $round
+        );
     }
 
     /**
@@ -279,5 +291,30 @@ class Statistics
     public function valuesToString(bool|int $sample = false): string
     {
         return ArrUtil::toString($this->values, $sample);
+    }
+
+    /**
+     * Caching-check for array to be numerical (for some functions).
+     *
+     * @return array<int|float>|null
+     */
+    public function numericalArray(): array|null
+    {
+        if ($this->containsNan === null) {
+            foreach ($this->values as $value) {
+                if (! is_numeric($value)) {
+                    $this->containsNan = true;
+
+                    break;
+                }
+            }
+        }
+        if ($this->containsNan) {
+            return null;
+        }
+        /** @var array<int|float> */
+        $numericalArray = $this->values;
+
+        return $numericalArray;
     }
 }

--- a/tests/StatisticTest.php
+++ b/tests/StatisticTest.php
@@ -194,7 +194,7 @@ it('calculates harmonic mean', function () {
     )->toBeNull();
 });
 
-it('cat distict numeric array', function () {
+it('can distinct numeric array', function () {
     expect(Statistics::make([1, 2, 3])->numericalArray())->toEqual([1, 2, 3]);
     expect(Statistics::make([1, '2', 3])->numericalArray())->toEqual([1, '2', 3]);
     expect(Statistics::make([])->numericalArray())->toEqual([]);

--- a/tests/StatisticTest.php
+++ b/tests/StatisticTest.php
@@ -193,3 +193,10 @@ it('calculates harmonic mean', function () {
         Statistics::make([])->harmonicMean()
     )->toBeNull();
 });
+
+it('cat distict numeric array', function () {
+    expect(Statistics::make([1, 2, 3])->numericalArray())->toEqual([1, 2, 3]);
+    expect(Statistics::make([1, '2', 3])->numericalArray())->toEqual([1, '2', 3]);
+    expect(Statistics::make([])->numericalArray())->toEqual([]);
+    expect(Statistics::make([1, 'some string', 3])->numericalArray())->toBeNull();
+});


### PR DESCRIPTION
Please, dont change types to `mixed`. `Stat::geometricMean()` could not process non-numeric data, because php can only multiply numbers (I am talking about the line `$product *= $value`), so passing mixed array, as allows parameter type, will make php to throw TypeError.

The stricter types you use, the easier it will be to support the library (that is one of the reasons, why typescript was created). 
It is cool that you are trying to use the strictest level of static analysis, but there is no point in it, if you don't use types.

Nevertheless, I've added the function `Statistics::numericalArray()` for checking if the array contains only numbers. It is caching (saving results in `Statistics::$containsNan`).

Another possible solution: add phpstan-ignore for the functions and do not check the array.

Please, take a look at #12.