### PR TITLE
Dropped support for PHP 8.0 and updated Pest to v2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0, 8.1, 8.2]
+        php: [8.1, 8.2]
         exclude:
-          - os: windows-latest
-            php: 8.0
           - os: windows-latest
             php: 8.1
 

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -34,4 +34,4 @@ jobs:
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute static code analysis
-        run: vendor/bin/phpstan analyse src --level 9 --error-format=github --no-progress --no-ansi
+        run: vendor/bin/phpstan analyse src --level 8 --error-format=github --no-progress --no-ansi

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "pestphp/pest": "^1.20",
+        "pestphp/pest": "^2.0",
         "phpstan/phpstan": "^1.3",
         "rector/rector": "^0.15.21"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
     executionOrder="random"
     failOnWarning="true"
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
+    cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="HiFolks Test Suite">
@@ -24,9 +17,6 @@
         </testsuite>
     </testsuites>
     <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
         <report>
             <html outputDirectory="build/coverage"/>
             <text outputFile="build/coverage.txt"/>
@@ -36,4 +26,9 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -64,6 +64,7 @@ class Stat
         if ($count & 1) {    // count is odd
             return $data[$index];
         }
+
         // count is even
         return match ($medianType) {
             self::MEDIAN_TYPE_LOW => ($data[$index - 1]),
@@ -423,6 +424,7 @@ class Stat
             $diffY = $valueY - $meanY;
             $add += ($diffX * $diffY);
         }
+
         // covariance for sample: N - 1
         return $add / floatval($countX - 1);
     }

--- a/src/Statistics.php
+++ b/src/Statistics.php
@@ -87,7 +87,7 @@ class Statistics
      *
      * @see Freq::relativeFrequencies()
      *
-     * @param  int  $round whether to round the result
+     * @param  int|null  $round whether to round the result
      * @return array<float>
      */
     public function relativeFrequencies(int $round = null): array


### PR DESCRIPTION
Hi,
Hope you're doing well.
In this PR, I changed the minimum PHP version to 8.1 and updated Pest PHP to version 2 (Closes #33).
Since Pest 2 uses PHPUnit v10, we had to update the old `phpunit.xml` to match the newer version's settings. I used `./vendor/bin/pest --migrate-configuration` command to upgrade the file. I also removed some settings like `stopOnFailure` and `processIsolation` since they were set to the default value of PHPUnit.

I understand the concept of mono PR, but on the way to updating, I fixed a function's doctype and ran the format script. :D