### PR TITLE
Updating rector support to 0.18.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "pestphp/pest": "^2.0",
         "phpstan/phpstan": "^1.3",
-        "rector/rector": "^0.15.21"
+        "rector/rector": "^0.18.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
@roberto-butti
Updating Rector support to version 0.18.5 was simple because this library did not make drastic changes to its structure. So the solution to this problem was limited to updating this dependency in composer.json. I performed the standard tests for this project before sending this pull request.

@aoscode