### PR TITLE
including Pint in all-check script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,12 @@
         }
     },
     "scripts": {
-        "pint": "vendor/bin/pint",
+        "format": "vendor/bin/pint",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
         "static-code": "vendor/bin/phpstan analyse -c phpstan.neon",
         "all-check": [
+            "@format",
             "@test",
             "@static-code"
         ]


### PR DESCRIPTION
When you run:

~~~
composer run all-check
~~~

also Pint execution is included