### PR TITLE
Fix deprecation for PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2 - WIP
+
+- Fix deprecations for PHP 8.4
+
 ## 1.0.1 - 2024-11-21
 
 - Welcome PHP 8.4

--- a/src/Freq.php
+++ b/src/Freq.php
@@ -141,10 +141,9 @@ class Freq
      * each class is not a range.
      *
      * @param  mixed[]  $data
-     * @param  ?int  $category
      * @return int[]
      */
-    public static function frequencyTable(array $data, int $category = null): array
+    public static function frequencyTable(array $data, ?int $category = null): array
     {
         $result = [];
         $min = floor((float) min($data));

--- a/src/Stat.php
+++ b/src/Stat.php
@@ -291,7 +291,7 @@ class Stat
      *
      * @return float the standard deviation of the numeric data
      */
-    public static function stdev(array $data, int $round = null): float
+    public static function stdev(array $data, ?int $round = null): float
     {
         $variance = self::variance($data);
 

--- a/src/Statistics.php
+++ b/src/Statistics.php
@@ -86,7 +86,7 @@ class Statistics
      * @param  int|null  $round whether to round the result
      * @return array<float>
      */
-    public function relativeFrequencies(int $round = null): array
+    public function relativeFrequencies(?int $round = null): array
     {
         return Freq::relativeFrequencies($this->values, $round);
     }

--- a/tests/StatFromCsvTest.php
+++ b/tests/StatFromCsvTest.php
@@ -8,7 +8,13 @@ it('parse CSV', function () {
     if (($handle = fopen(getcwd() . '/tests/data/income.data.csv', 'r')) !== false) {
         $x = [];
         $y = [];
-        while (($data = fgetcsv($handle, 1000, ',')) !== false) {
+        while (($data = fgetcsv(
+            $handle,
+            1000,
+            separator: ',',
+            enclosure: '"',
+            escape: "",
+        )) !== false) {
             $num = count($data);
             expect($num)->toEqual(3);
             $row++;


### PR DESCRIPTION
Fixed deprecation for PHP 8.4:
- https://php.watch/versions/8.4/csv-functions-escape-parameter
- https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated